### PR TITLE
Use cmd options for configuration

### DIFF
--- a/cmd/ghsync/main.go
+++ b/cmd/ghsync/main.go
@@ -5,14 +5,13 @@ import (
 	"database/sql"
 	"fmt"
 	"net/http"
-	"os"
+
+	"github.com/src-d/ghsync"
+	"github.com/src-d/ghsync/utils"
 
 	"github.com/google/go-github/github"
 	"github.com/gregjones/httpcache"
 	"github.com/gregjones/httpcache/diskcache"
-
-	"github.com/src-d/ghsync"
-	"github.com/src-d/ghsync/utils"
 	"golang.org/x/oauth2"
 	"gopkg.in/src-d/go-cli.v0"
 	"gopkg.in/src-d/go-queue.v1"
@@ -36,42 +35,66 @@ func main() {
 
 type syncCommand struct {
 	cli.Command `name:"sync"`
+
+	Token string `long:"token" env:"GHSYNC_TOKEN" description:"GitHub personal access token" required:"true"`
+	Org   string `long:"org" env:"GHSYNC_ORG" description:"Name of the GitHub organization" required:"true"`
+
+	QueueOpt struct {
+		Queue  string `long:"queue" env:"GHSYNC_QUEUE" description:"queue name. If it's not set the organization name will be used"`
+		Broker string `long:"broker" env:"GHSYNC_BROKER" default:"amqp://localhost:5672" description:"broker service URI"`
+	} `group:"go-queue connection options"`
+
+	PostgresOpt struct {
+		DB       string `long:"postgres-db" env:"GHSYNC_POSTGRES_DB" description:"PostgreSQL DB" default:"ghsync"`
+		User     string `long:"postgres-user" env:"GHSYNC_POSTGRES_USER" description:"PostgreSQL user" default:"superset"`
+		Password string `long:"postgres-password" env:"GHSYNC_POSTGRES_PASSWORD" description:"PostgreSQL password" default:"superset"`
+		Host     string `long:"postgres-host" env:"GHSYNC_POSTGRES_HOST" description:"PostgreSQL host" default:"localhost"`
+		Port     int    `long:"postgres-port" env:"GHSYNC_POSTGRES_PORT" description:"PostgreSQL port" default:"5432"`
+	} `group:"PostgreSQL connection options"`
 }
 
 func (c *syncCommand) Execute(args []string) error {
 	psqlInfo := fmt.Sprintf("host=%s port=%d user=%s "+
 		"password=%s dbname=%s sslmode=disable",
-		"localhost", 5432, "superset", "superset", "ghsync")
+		c.PostgresOpt.Host, c.PostgresOpt.Port, c.PostgresOpt.User,
+		c.PostgresOpt.Password, c.PostgresOpt.DB)
 	db, err := sql.Open("postgres", psqlInfo)
 	if err != nil {
 		return err
 	}
 	defer db.Close()
 
-	org := os.Getenv("GITHUB_ORG")
+	err = db.Ping()
+	if err != nil {
+		return err
+	}
 
 	http := oauth2.NewClient(context.TODO(), oauth2.StaticTokenSource(
-		&oauth2.Token{AccessToken: os.Getenv("GITHUB_TOKEN")},
+		&oauth2.Token{AccessToken: c.Token},
 	))
 
-	t := httpcache.NewTransport(diskcache.New("cache/" + org))
+	t := httpcache.NewTransport(diskcache.New("cache/" + c.Org))
 	t.Transport = &RemoveHeaderTransport{utils.NewRateLimitTransport(http.Transport)}
 	http.Transport = t
 
 	client := github.NewClient(http)
 
-	broker, err := queue.NewBroker("amqp://localhost:5672")
+	broker, err := queue.NewBroker(c.QueueOpt.Broker)
 	if err != nil {
 		return err
 	}
 
-	queue, err := broker.Queue(org)
+	qName := c.QueueOpt.Queue
+	if qName == "" {
+		qName = c.Org
+	}
+	queue, err := broker.Queue(qName)
 	if err != nil {
 		return err
 	}
 
 	syncer := ghsync.NewSyncer(db, client, queue)
-	go syncer.DoOrganization(org)
+	go syncer.DoOrganization(c.Org)
 	fmt.Println(syncer.Wait())
 
 	return nil

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '3.2'
+services:
+  postgres:
+    image: postgres:10
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ghsync
+      POSTGRES_PASSWORD: superset
+      POSTGRES_USER: superset
+    ports:
+      - 5432:5432
+    volumes:
+      - postgres:/var/lib/postgresql/data
+
+  rabbitmq:
+    image: "rabbitmq:3-management"
+    restart: always
+    ports:
+      - "8081:15672"
+      - "5672:5672"
+
+volumes:
+  postgres:
+    external: false


### PR DESCRIPTION
Part of #6.

Adds configuration with cli options or environment variables.

I also added a `docker-compose.yml` file here. This way we can create the dependencies and test things with a compose file that will be eventually moved to `sourced-ce`

```
$ go run cmd/ghsync/main.go sync -h
Usage:
  ghsync [OPTIONS] sync [sync-OPTIONS]

Help Options:
  -h, --help                                     Show this help message

[sync command options]
          --token=                               GitHub personal access token [$GHSYNC_TOKEN]
          --org=                                 Name of the GitHub organization [$GHSYNC_ORG]

    Log Options:
          --log-level=[info|debug|warning|error] Logging level (default: info) [$LOG_LEVEL]
          --log-format=[text|json]               log format, defaults to text on a terminal and json otherwise [$LOG_FORMAT]
          --log-fields=                          default fields for the logger, specified in json [$LOG_FIELDS]
          --log-force-format                     ignore if it is running on a terminal or not [$LOG_FORCE_FORMAT]

    Profiler Options:
          --profiler-http                        start HTTP profiler endpoint [$PROFILER_HTTP]
          --profiler-block-rate=                 runtime.SetBlockProfileRate parameter (default: 0) [$PROFILER_BLOCK_RATE]
          --profiler-mutex-rate=                 runtime.SetMutexProfileFraction parameter (default: 0) [$PROFILER_MUTEX_FRACTION]
          --profiler-endpoint=                   address to bind HTTP pprof endpoint to (default: 0.0.0.0:6061) [$PROFILER_ENDPOINT]
          --profiler-cpu=                        file where to write the whole execution CPU profile [$PROFILER_CPU]

    go-queue connection options:
          --queue=                               queue name. If it's not set the organization name will be used [$GHSYNC_QUEUE]
          --broker=                              broker service URI (default: amqp://localhost:5672) [$GHSYNC_BROKER]

    PostgreSQL connection options:
          --postgres-db=                         PostgreSQL DB (default: ghsync) [$GHSYNC_POSTGRES_DB]
          --postgres-user=                       PostgreSQL user (default: superset) [$GHSYNC_POSTGRES_USER]
          --postgres-password=                   PostgreSQL password (default: superset) [$GHSYNC_POSTGRES_PASSWORD]
          --postgres-host=                       PostgreSQL host (default: localhost) [$GHSYNC_POSTGRES_HOST]
          --postgres-port=                       PostgreSQL port (default: 5432) [$GHSYNC_POSTGRES_PORT]


```