### PR TITLE
Add Dockerfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,4 +47,4 @@ jobs:
         on:
           all_branches: true
       after_deploy:
-        # - make docker-push-latest-release
+        - make docker-push-latest-release

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM alpine
+
+RUN apk update && \
+  apk add ca-certificates && \
+  rm -rf /var/cache/apk/*
+
+COPY ./build/bin/ghsync /bin/ghsync
+
+ENTRYPOINT ["/bin/ghsync"]

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 PROJECT = ghsync
 COMMANDS = cmd/ghsync
 
+GO_BUILD_ENV = CGO_ENABLED=0
 PKG_OS = darwin linux
 
 # Add prerequisites

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,9 +4,9 @@ services:
     image: postgres:10
     restart: unless-stopped
     environment:
-      POSTGRES_DB: ghsync
-      POSTGRES_PASSWORD: superset
-      POSTGRES_USER: superset
+      POSTGRES_DB: ${POSTGRES_DB:-ghsync}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-superset}
+      POSTGRES_USER: ${POSTGRES_USER:-superset}
     ports:
       - 5432:5432
     volumes:
@@ -18,6 +18,25 @@ services:
     ports:
       - "8081:15672"
       - "5672:5672"
+
+  ghsync:
+    image: srcd/ghsync
+    entrypoint: ["/bin/sh"]
+    command: ["-c", "sleep 30s && ghsync migrate && ghsync sync"]
+    depends_on:
+      - postgres
+      - rabbitmq
+    environment:
+      GHSYNC_TOKEN: ${GHSYNC_TOKEN}
+      GHSYNC_ORG: ${GHSYNC_ORG}
+
+      GHSYNC_POSTGRES_DB: ${POSTGRES_DB:-ghsync}
+      GHSYNC_POSTGRES_USER: ${POSTGRES_USER:-superset}
+      GHSYNC_POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-superset}
+      GHSYNC_POSTGRES_HOST: postgres
+      GHSYNC_POSTGRES_PORT: 5432
+
+      GHSYNC_BROKER: amqp://rabbitmq:5672
 
 volumes:
   postgres:


### PR DESCRIPTION
Fix #5.

This PR adds the Dockerfile.
The entrypoint does not run any sub command by default, because `sync` will fail without calling `migrate` first. Both are needed, so I though it makes sense to leave `ghsync` and it will print the help by default.
```
$ docker run srcd/ghsync
Please specify one command of: completion, migrate, sync or version
Usage:
...
```

`ca-certificates` added for the `https` github endpoints.

I left a `sleep` in `docker-compose.yml` to wait for postgres & rabbitmq initialization. This can be improved in a couple of ways:
- make ghsync actively retry the connection. Maybe every 5s for 2m.
- make the docker entrypoint a wrapper that pings and waits for postgres & rabbitmq.

I didn't want to complicate it now, as this can be reconsidered when we have a better understanding of how this will be integrated in sourced-ce.