### PR TITLE
Support a list or organizations in shallow cmd

### DIFF
--- a/cmd/ghsync/subcmd/shallow.go
+++ b/cmd/ghsync/subcmd/shallow.go
@@ -1,6 +1,8 @@
 package subcmd
 
 import (
+	"strings"
+
 	"github.com/src-d/ghsync/shallow"
 
 	"gopkg.in/src-d/go-cli.v0"
@@ -10,7 +12,7 @@ type ShallowCommand struct {
 	cli.Command `name:"shallow" short-description:"Shallow sync of GitHub data" long-description:"Shallow sync of GitHub data"`
 
 	Token string `long:"token" env:"GHSYNC_TOKEN" description:"GitHub personal access token" required:"true"`
-	Org   string `long:"org" env:"GHSYNC_ORG" description:"Name of the GitHub organization" required:"true"`
+	Orgs  string `long:"orgs" env:"GHSYNC_ORGS" description:"Comma-separated list of GitHub organization names" required:"true"`
 
 	Postgres PostgresOpt `group:"PostgreSQL connection options"`
 }
@@ -28,5 +30,12 @@ func (c *ShallowCommand) Execute(args []string) error {
 	}
 
 	orgSyncer := shallow.NewOrganizationSyncer(db, client)
-	return orgSyncer.Sync(c.Org)
+	for _, o := range strings.Split(c.Orgs, ",") {
+		err = orgSyncer.Sync(o)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
Fix #1.

Done on top of #32, only the last commit is relevant.
I did not change the argument name, but maybe we want it to be `--orgs/GHSYNC_ORGS` 

Did some quick tests and it seems to work without any further problem.
![image](https://user-images.githubusercontent.com/1469173/59758737-7fdd6700-9286-11e9-8a01-c8fbdad6f09f.png)
