### PR TITLE
Add validate sub command

### DIFF
--- a/cmd/ghsync/main.go
+++ b/cmd/ghsync/main.go
@@ -20,6 +20,7 @@ func main() {
 	app.AddCommand(&subcmd.ShallowCommand{})
 	app.AddCommand(&subcmd.DeepCommand{})
 	app.AddCommand(&subcmd.MigrateCommand{})
+	app.AddCommand(&subcmd.ValidateCommand{})
 
 	app.RunMain()
 }

--- a/cmd/ghsync/subcmd/common.go
+++ b/cmd/ghsync/subcmd/common.go
@@ -23,6 +23,11 @@ import (
 
 const maxVersion uint = 1560510971
 
+type GithubOptions struct {
+	Token string `long:"token" env:"GHSYNC_TOKEN" description:"GitHub personal access token" required:"true"`
+	Orgs  string `long:"orgs" env:"GHSYNC_ORGS" description:"Comma-separated list of GitHub organization names" required:"true"`
+}
+
 type PostgresOpt struct {
 	DB       string `long:"postgres-db" env:"GHSYNC_POSTGRES_DB" description:"PostgreSQL DB" default:"ghsync"`
 	User     string `long:"postgres-user" env:"GHSYNC_POSTGRES_USER" description:"PostgreSQL user" default:"superset"`

--- a/cmd/ghsync/subcmd/shallow.go
+++ b/cmd/ghsync/subcmd/shallow.go
@@ -11,9 +11,7 @@ import (
 type ShallowCommand struct {
 	cli.Command `name:"shallow" short-description:"Shallow sync of GitHub data" long-description:"Shallow sync of GitHub data"`
 
-	Token string `long:"token" env:"GHSYNC_TOKEN" description:"GitHub personal access token" required:"true"`
-	Orgs  string `long:"orgs" env:"GHSYNC_ORGS" description:"Comma-separated list of GitHub organization names" required:"true"`
-
+	GithubOptions
 	Postgres PostgresOpt `group:"PostgreSQL connection options"`
 }
 

--- a/cmd/ghsync/subcmd/validate.go
+++ b/cmd/ghsync/subcmd/validate.go
@@ -1,0 +1,40 @@
+package subcmd
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"gopkg.in/src-d/go-cli.v0"
+)
+
+type ValidateCommand struct {
+	cli.Command `name:"validate" short-description:"Validate token and list of organizations" long-description:"Validate token and list of organizations.\nReturns 0 exit code in case of success and 1 exit code on error."`
+
+	GithubOptions
+}
+
+func (c *ValidateCommand) Execute(args []string) error {
+	client, err := newClient(c.Token)
+	if err != nil {
+		return err
+	}
+
+	_, resp, err := client.Users.Get(context.TODO(), "")
+	if resp.StatusCode == http.StatusUnauthorized {
+		return fmt.Errorf("github token is not valid")
+	}
+
+	for _, org := range strings.Split(c.Orgs, ",") {
+		_, resp, err := client.Organizations.Get(context.TODO(), org)
+		if resp.StatusCode == http.StatusNotFound {
+			return fmt.Errorf("organization '%s' is not found", org)
+		}
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
Accepts the same arguments as shallow command for a token and list of
organizations.

To validate the token makes request to `/me` endpoint that doesn't
require any special permissions.

To validate organizations makes requests to `/orgs/<name>`.

Returns human friendly errors in 2 most common cases:
- Invalid token (unauthorized error)
- Organization doesn't exist

For any other errors it returns go-github error as is.

Example output:
```
$ ghsync validate --token=not-valid --orgs=src-d,thisorgshouldnotexistforsurebecauseisaidso
github token is not valid
exit status 1
$ ghsync validate --token=<valid> --orgs=src-d,thisorgshouldnotexistforsurebecauseisaidso
organization 'thisorgshouldnotexistforsurebecauseisaidso' is not found
exit status 1
$ ghsync validate --token=<valid> --orgs=src-d
$ echo $?
0
```

Ref: https://github.com/src-d/sourced-ce/issues/59