### PR TITLE
 Make ghsync exit 0 and warn when no org is passed

### DIFF
--- a/cmd/ghsync/subcmd/shallow.go
+++ b/cmd/ghsync/subcmd/shallow.go
@@ -21,6 +21,13 @@ type ShallowCommand struct {
 }
 
 func (c *ShallowCommand) Execute(args []string) error {
+	if c.Orgs == "" {
+		log.Warningf("no organizations found, at least one " +
+			"organization must be provided")
+
+		return nil
+	}
+
 	db, err := c.Postgres.initDB()
 	if err != nil {
 		return err


### PR DESCRIPTION
fix #54
same as in https://github.com/src-d/gitcollector/pull/65

As used in source{d} CE, and also implemented in gitcollector,
ghsync will warn if no organization is passed, and will exit 0
